### PR TITLE
Add padding support for bytes32/hex

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -117,6 +117,18 @@ footer a:active {
   color: #fff;
 }
 
+#applyPaddingContainer {
+  display: none;
+}
+
+#applyPadding {
+  margin-left: 1rem;
+}
+
+label[for=applyPadding] {
+  margin-left: 5px;
+}
+
 /* ==========================================================================
    Media Queries
    ========================================================================== */

--- a/src/index.html
+++ b/src/index.html
@@ -29,6 +29,11 @@
           <option value="number">number/decimal</option>
           <option value="string" selected="selected">string/utf-8/ascii</option>
         </select>
+
+        <span id="applyPaddingContainer">
+          <input type="checkbox" id="applyPadding">
+          <label for="applyPadding">Apply padding</label>        
+        </span>
       </section>
 
       <section>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3,10 +3,14 @@
   const input = document.getElementById('input');
   const toType = document.getElementById('to');
   const output = document.getElementById('output');
+  const applyPadding = document.getElementById('applyPadding');
+  const applyPaddingContainer = document.getElementById('applyPaddingContainer');
 
   const convert = (value) => {
     if (toType.value === 'bytes32') {
-      output.value = web3.toHex(value);
+      const v = web3.toHex(value);
+
+      output.value = applyPadding.checked ? web3.padRight(v, 66) : v;
     }
     if (toType.value === 'number') {
       output.value = web3.toDecimal(value);
@@ -22,5 +26,9 @@
 
   input.addEventListener('keyup', () => convert(input.value));
   input.addEventListener('blur', () => convert(input.value));
-  toType.addEventListener('change', () => convert(input.value));
+  toType.addEventListener('change', () => {
+    applyPaddingContainer.style.display = toType.value === 'bytes32' ? 'inline' : 'none';
+    convert(input.value);
+  });
+  applyPadding.addEventListener('change', () => convert(input.value));
 })();


### PR DESCRIPTION
Addresses issue #2 

Adds a "padding" checkbox when conversion is made to `bytes32/hex`

![image](https://user-images.githubusercontent.com/31542280/168494047-48191739-4574-4a41-a263-5cd0c3db2fc6.png)
